### PR TITLE
Fix Command Injection Vulnerability in pack.js

### DIFF
--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -1,5 +1,28 @@
 const fs = require('fs')
 const child_process = require('child_process');
+
+function validateSecurity(input, name) {
+    const safeRegex = /^[a-zA-Z0-9._-]+$/;
+    if (input && !safeRegex.test(String(input))) {
+        console.error(`[SECURITY FATAL] Invalid characters in ${name}`);
+        process.exit(1); 
+    }
+}
+
+const targets_raw = process.argv[2] || ""
+const type_raw = process.argv[3] || ""
+const buildnumber = process.argv[4] || "0"
+const channel = process.argv[5] || "nightly"
+
+// 校验原始输入，防止注入字符进入拼接逻辑
+validateSecurity(buildnumber, "buildnumber");
+validateSecurity(channel, "channel");
+targets_raw.split(";").forEach(t => t && validateSecurity(t, "targets"));
+type_raw.split(";").forEach(t => t && validateSecurity(t, "type"));
+
+const targets = targets_raw.split(";")
+const type = type_raw.split(";")
+
 const targets = process.argv[2].split(";")
 const type = process.argv[3].split(";")
 const { apps, services, step_file } = require('./build_config')
@@ -210,9 +233,9 @@ async function run() {
                 let fid = get_step_arg(service.name, PublishStep.Upload)
                 let app_version = version + "-preview";
 
-                if (!/^[a-zA-Z0-9._-]+$/.test(app_version) || !/^[a-zA-Z0-9._-]+$/.test(fid)) {
-                    throw new Error("Invalid characters detected in version or fid");
-                }
+                validateSecurity(app_version, "app_version");
+                validateSecurity(fid, "fid");
+                validateSecurity(service.id, "service.id");
                 
                 let cmd = `app-tool app set -v ${app_version} -s ${fid} ${service.id} -o ${repo_path}`;
                 console.log("will run app tool cmd:", cmd)

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -209,6 +209,11 @@ async function run() {
                 // 运行app-tool，添加版本和fid
                 let fid = get_step_arg(service.name, PublishStep.Upload)
                 let app_version = version + "-preview";
+
+                if (!/^[a-zA-Z0-9._-]+$/.test(app_version) || !/^[a-zA-Z0-9._-]+$/.test(fid)) {
+                    throw new Error("Invalid characters detected in version or fid");
+                }
+                
                 let cmd = `app-tool app set -v ${app_version} -s ${fid} ${service.id} -o ${repo_path}`;
                 console.log("will run app tool cmd:", cmd)
                 child_process.execSync(cmd, { cwd: 'dist', stdio: 'inherit' })

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -1,28 +1,5 @@
 const fs = require('fs')
 const child_process = require('child_process');
-
-function validateSecurity(input, name) {
-    const safeRegex = /^[a-zA-Z0-9._-]+$/;
-    if (input && !safeRegex.test(String(input))) {
-        console.error(`[SECURITY FATAL] Invalid characters in ${name}`);
-        process.exit(1); 
-    }
-}
-
-const targets_raw = process.argv[2] || ""
-const type_raw = process.argv[3] || ""
-const buildnumber = process.argv[4] || "0"
-const channel = process.argv[5] || "nightly"
-
-// 校验原始输入，防止注入字符进入拼接逻辑
-validateSecurity(buildnumber, "buildnumber");
-validateSecurity(channel, "channel");
-targets_raw.split(";").forEach(t => t && validateSecurity(t, "targets"));
-type_raw.split(";").forEach(t => t && validateSecurity(t, "type"));
-
-const targets = targets_raw.split(";")
-const type = type_raw.split(";")
-
 const targets = process.argv[2].split(";")
 const type = process.argv[3].split(";")
 const { apps, services, step_file } = require('./build_config')
@@ -31,6 +8,11 @@ const assert = require('assert');
 
 const buildnumber = process.argv[4] || "0"
 const channel = process.argv[5] || "nightly"
+
+if (!/^\d+$/.test(buildnumber)) {
+    console.error('invalid buildnumber')
+    process.exit(1)
+}
 
 if (!fs.existsSync('Cargo.toml')) {
     console.error('cannot find Cargo.toml in cwd! check working dir')
@@ -148,7 +130,12 @@ if (!file_repo_path) {
 }
 
 function get_obj_id(desc_file) {
-    let out = child_process.execSync(`${path.join('dist', 'desc-tool')} show ${desc_file}`, {encoding: 'utf8'})
+    let out = child_process.execFileSync(
+        path.join('dist', 'desc-tool'),
+        ['show', desc_file],
+        { encoding: 'utf8' }
+    )
+
     let obj_id
     for (const line of out.split('\n')) {
         if (line.startsWith('objectid:')) {
@@ -216,14 +203,22 @@ async function run() {
                         }
                     }
 
-                    child_process.execSync(`bash -c "./pack-tools -d services/${service.name}/${target}"`, { cwd: 'dist', stdio: 'inherit' })
+                    child_process.execFileSync(
+                        'bash',
+                        ['-c', './pack-tools -d "$1"', 'bash', `services/${service.name}/${target}`],
+                        { cwd: 'dist', stdio: 'inherit' }
+                    )
                     fs.rmSync(`dist/services/${service.name}/${target}`, {recursive: true, force: true});
                 }
                 set_step(service.name, PublishStep.Pack)
             }
 
             if (need_step(service.name, PublishStep.Upload)) {
-                child_process.execSync(`cyfs-client put services/${service.name} -f fid -o ${file_repo_path} --tcp`, { cwd: 'dist', stdio: 'inherit' })
+                child_process.execFileSync(
+                    'cyfs-client',
+                    ['put', `services/${service.name}`, '-f', 'fid', '-o', file_repo_path, '--tcp'],
+                    { cwd: 'dist', stdio: 'inherit' }
+                )
                 let fid = fs.readFileSync('dist/fid', {encoding: 'utf-8'})
                 set_step(service.name, PublishStep.Upload, fid)
             }
@@ -232,14 +227,14 @@ async function run() {
                 // 运行app-tool，添加版本和fid
                 let fid = get_step_arg(service.name, PublishStep.Upload)
                 let app_version = version + "-preview";
-
-                validateSecurity(app_version, "app_version");
-                validateSecurity(fid, "fid");
-                validateSecurity(service.id, "service.id");
-                
                 let cmd = `app-tool app set -v ${app_version} -s ${fid} ${service.id} -o ${repo_path}`;
                 console.log("will run app tool cmd:", cmd)
-                child_process.execSync(cmd, { cwd: 'dist', stdio: 'inherit' })
+
+                child_process.execFileSync(
+                    'app-tool',
+                    ['app', 'set', '-v', app_version, '-s', fid, service.id, '-o', repo_path],
+                    { cwd: 'dist', stdio: 'inherit' }
+                )
                 set_step(service.name, PublishStep.SetVersion, version)
             }
 
@@ -258,4 +253,3 @@ run().then(() => {
     fs.rmSync(step_file, {force: true, maxRetries: 3})
     process.exit(0)
 })
-


### PR DESCRIPTION
# Command Injection Reproduction Notes for `pack.js`
## Summary

Hello,

I am writing to report a potential OS Command Injection vulnerability in the following file:

`pack.js`

The issue appears when user-controlled input is used to construct shell command strings that are later executed via `child_process.execSync(...)`.

The script is designed to package and publish services. It reads the `buildnumber` value from command-line arguments and uses it to construct a version string. The generated version is then used to construct an `app-tool app set ...` shell command.

Because the input is not sanitized before being passed to `child_process.execSync(...)`, a local attacker or CI user who can control the release script arguments can execute arbitrary OS commands.

This is a local/CI command injection vulnerability, not a remote command execution vulnerability.

## Root Cause

The issue is caused by unsafe shell command construction in the following logic:

```js
const buildnumber = process.argv[4] || "0"
const channel = process.argv[5] || "nightly"

let version = `1.1.${version_from_channel(channel)}.${buildnumber}`;
```

Later, the generated version is used to construct a shell command:

```js
if (need_step(service.name, PublishStep.SetVersion)) {
    let fid = get_step_arg(service.name, PublishStep.Upload)

    let app_version = version + "-preview";

    let cmd = `app-tool app set -v ${app_version} -s ${fid} ${service.id} -o ${repo_path}`;

    console.log("will run app tool cmd:", cmd)

    child_process.execSync(cmd, {
        cwd: 'dist',
        stdio: 'inherit'
    })

    set_step(service.name, PublishStep.SetVersion, version)
}
```

An attacker can use shell metacharacters, such as `&`, `|`, or `;`, within the `buildnumber` argument to break out of the intended `app-tool` command and run additional programs.

For example, on Windows, a malicious `buildnumber` can be:

```text
123 & node -e "require('fs').writeFileSync('../pwned_pack.txt','command injection triggered')" & rem
```

This causes the final command to become:

```text
app-tool app set -v 1.1.0.123 & node -e "require('fs').writeFileSync('../pwned_pack.txt','command injection triggered')" & rem -preview -s mock-fid-12345 test-service-id -o <repo_path>
```

The Windows shell interprets `&` as a command separator, so the injected command is executed.

## Reproduction Material

A professional Proof of Concept script is provided in: `poc_pack.js`

`poc_pack.js`

This Proof of Concept (PoC) is intended to demonstrate that external input can reach dangerous command execution logic through the vulnerable code path.

### What the PoC Does

The PoC automates the exploitation process to ensure a reliable and visible demonstration:

1. Environment Preparation: It creates an isolated `.poc_pack_workspace` directory and copies the original `pack.js` into it.

2. Mocking Build Environment: It creates the required mock files, including `Cargo.toml`, `build_config.js`, `step.json`, and `dist/`, so that the script can reach the vulnerable `SetVersion` step.

3. Mocking Network and Descriptor Commands: It mocks HTTP/HTTPS requests and returns fake output for the `desc-tool` command to allow the script to continue.

4. Real Sink Verification: It lets the original `pack.js` construct the real `app-tool app set ...` command and reach the real `child_process.execSync(cmd)` sink.

5. Automated Injection: It passes the malicious payload through `process.argv[4]` as the `buildnumber`.

6. Verification: It checks whether `pwned_pack.txt` is created, proving that the injected command was executed by the system shell.

## Example Payload

The PoC uses the following payload for the `buildnumber` argument:

```bash
123 & node -e "require('fs').writeFileSync('../pwned_pack.txt','command injection triggered')" & rem
```

## How to Run

Ensure you are in the directory containing both files and run:

```bash
node poc_pack.js
```

## Expected Output

Upon successful execution, you will see:

```text
[*] Malicious buildnumber: 123 & node -e "require('fs').writeFileSync('../pwned_pack.txt','command injection triggered')" & rem

[*] Loading original pack.js...

[execSync called]
dist\desc-tool show <workspace>\.poc_pack_workspace\dist\repo.desc

[mock] desc-tool output returned

get repo account mock-object-id balance 100000

[execSync called]
dist\desc-tool show <workspace>\.poc_pack_workspace\dist\file_repo.desc

[mock] desc-tool output returned

get file repo account mock-object-id balance 100000

will run app tool cmd:

app-tool app set -v 1.1.0.123 & node -e "require('fs').writeFileSync('../pwned_pack.txt','command injection triggered')" & rem -preview -s mock-fid-12345 test-service-id -o <workspace>\.poc_pack_workspace\dist\repo

[execSync called]

app-tool app set -v 1.1.0.123 & node -e "require('fs').writeFileSync('../pwned_pack.txt','command injection triggered')" & rem -preview -s mock-fid-12345 test-service-id -o <workspace>\.poc_pack_workspace\dist\repo

[+] Reached real vulnerable sink in pack.js

[+] Now executing the real command string through execSync...

'app-tool' 不是内部或外部命令，也不是可运行的程序
或批处理文件。

========== PoC Result ==========

[+] Success: command injection confirmed.

[+] Marker file created:
<workspace>\.poc_pack_workspace\pwned_pack.txt

[+] This proves the payload from buildnumber reached the real execSync sink.
```

The `app-tool` error does not affect the result.

In the test environment, `app-tool` may not be installed, but the injected command is still executed by the shell.

The creation of `pwned_pack.txt` proves that command injection occurred.

## Patch Explanation

This branch also includes a patched version of `pack.js` intended to mitigate the command injection risk described above.

### What the patch changes

The patch introduces validation before the build number is used by:

- `SetVersion`

In the vulnerable version, the user-controlled value:

```text
process.argv[4]
```

(assigned to `buildnumber`)

could be concatenated into `version` and `app_version`, then embedded into the `app-tool app set ...` command and executed via `child_process.execSync(...)` without sufficient checks.

The patched version introduces input checks before these values are passed into command execution logic.

### Validation introduced by the patch

The patch adds simple validation to ensure only expected build values are accepted.

### Build number validation

Build number values are restricted to numeric formats.

Values containing unexpected characters or shell metacharacters are rejected.

### Safe Command Execution

The patch avoids executing a fully concatenated shell command string.

The command should be executed with separated arguments so user-controlled values are not interpreted as shell syntax.

If validation fails, the value is rejected instead of being passed into command execution.